### PR TITLE
Disable keyboard arrow keys from skipping the user through steps when…

### DIFF
--- a/app/assets/javascripts/program_streams/form.coffee
+++ b/app/assets/javascripts/program_streams/form.coffee
@@ -283,6 +283,7 @@ CIF.Program_streamsNew = CIF.Program_streamsEdit = CIF.Program_streamsCreate = C
       headerTag: 'h4'
       bodyTag: 'section'
       transitionEffect: 'slideLeft'
+      enableKeyNavigation: false
 
       onStepChanging: (event, currentIndex, newIndex) ->
         if currentIndex == 0 and newIndex == 1 and $('#description').is(':visible')


### PR DESCRIPTION
… they are editing a CPS