### PR TITLE
error when switching to other language

### DIFF
--- a/app/assets/javascripts/client_advance_search.coffee
+++ b/app/assets/javascripts/client_advance_search.coffee
@@ -38,7 +38,7 @@ class CIF.ClientAdvanceSearch
       deleteGroup: $('#builder, #wizard-builder').data('filter-translation-delete-group')
 
   formatSpecialCharacter: (value) ->
-    filedName = value.toLowerCase().replace(/[^a-zA-Z0-9]+/gi, ' ').trim()
+    filedName = value.toLowerCase().replace(/[^a-zA-Z0-9]+/gi, ' ').trim() || value.trim()
     filedName.replace(/ /g, '_')
 
   removeCheckboxColumnPicker: (element, name) ->


### PR DESCRIPTION
Reproduce bug:
- switching language to khmer.
- choose khmer title custom form or contain space title custom form.
- open column picker or browser console to see the error.