### PR TITLE
Search result display incorrect in report builder on 'is not' condition with created_by, age, enrolled_program_stream  167866391

### DIFF
--- a/app/classes/advanced_searches/client_advanced_search.rb
+++ b/app/classes/advanced_searches/client_advanced_search.rb
@@ -37,7 +37,7 @@ module AdvancedSearches
             excluded_client_ids = rules['rules'].flatten.map{|rule| rule['value'] if rule['operator'] == 'not_equal'}
           else
             excluded_client_ids = rules.flatten.map{|rule| rule['value'] if rule['operator'] == 'not_equal'}
-          end   
+          end
           # clients = @clients.joins(:client_enrollments).where(client_enrollments: { status: 'Active' }).where(query_array) do |client|
           #   client_enrollment_ids = client.client_enrollments.map(&:program_stream_id)
           #   client_enrollment_ids.any? { |e| excluded_client_ids.compact.include?(e.to_s) }

--- a/app/classes/advanced_searches/client_association_filter.rb
+++ b/app/classes/advanced_searches/client_association_filter.rb
@@ -124,7 +124,7 @@ module AdvancedSearches
     end
 
     def created_by_user_query
-      user    = ''                       
+      user    = ''
       clients = @clients.joins(:versions)
       user    = User.find(@value) if @value.present?
       client_ids = []
@@ -699,7 +699,7 @@ module AdvancedSearches
       when 'not_equal'
         # clients = @clients.where.not(date_of_birth: date_value_format.last_year.tomorrow..date_value_format)
         clients = @clients.where("clients.date_of_birth is NULL OR (EXTRACT(year FROM age(current_date, date_of_birth)) :: int) != ?", @value)
-      when 'less' 
+      when 'less'
         clients = @clients.where('date_of_birth > ?', date_value_format)
       when 'less_or_equal'
         clients = @clients.where('date_of_birth >= ?', date_value_format.last_year)


### PR DESCRIPTION
@kirykr 
Please kindly to check this branches.