### PR TITLE
Prevent duplicate/wrong domains population

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -144,7 +144,7 @@ class Assessment < ActiveRecord::Base
   private
 
   def populate_domains
-    self.assessment_domains = AssessmentDomainsLoader.call(self) if new_record?
+    self.assessment_domains = AssessmentDomainsLoader.call(self) if new_record? && client_id?
   end
 
   def allow_create

--- a/app/services/assessment_domains_loader.rb
+++ b/app/services/assessment_domains_loader.rb
@@ -6,7 +6,7 @@ class AssessmentDomainsLoader < ServiceBase
   end
 
   def call
-    return if assessment.persisted?
+    return assessment.assessment_domains if assessment.persisted? || assessment.client_id.blank?
 
     domains.map do |domain|
       case_conference_domain = assessment.case_conference.case_conference_domains.find_by(domain_id: domain.id) if assessment.case_conference


### PR DESCRIPTION
This is to prevent `AssessmentDomainsLoader` from loading assessment domain when parent is not client.